### PR TITLE
Fix/socket inconsistency

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ const { EVENT } = constants;
 const app = express();
 const server = http.createServer(app);
 
-const io = new Server(server, {
+export const io = new Server(server, {
     cors: {
         origin: '*',
     },

--- a/src/services/eventLog/index.ts
+++ b/src/services/eventLog/index.ts
@@ -21,7 +21,7 @@ export async function getAll({
                 [Op.lte]: toId,
             },
         },
-        order: [['id', 'DESC']],
+        order: [['id', 'ASC']],
         raw: true,
     });
 }

--- a/src/services/eventLog/index.ts
+++ b/src/services/eventLog/index.ts
@@ -52,11 +52,11 @@ export function webSocketFormat(
             }
             if (tx.event_type === EventType.fork) return true;
 
-            const findAcounts = (
+            const hasAccountAmongReceivers = (
                 tx.data.trace.action_traces as { receiver: string }[]
             ).some(({ receiver }) => accounts.includes(receiver));
 
-            return findAcounts;
+            return hasAccountAmongReceivers;
         })
         .map((tx) => {
             if (tx.event_type === EventType.trace) {

--- a/src/services/eventLog/index.ts
+++ b/src/services/eventLog/index.ts
@@ -34,13 +34,21 @@ export async function getMaxEventLog(blockNum: number) {
     });
 }
 
-export function webSocketFormat(eventLogs: EventLog[], accounts: string[]) {
+export function webSocketFormat(
+    eventLogs: EventLog[],
+    accounts: string[],
+    lastEventLogId: number,
+    lastCheckedBlock: number
+) {
     const parsedTraces = eventLogs.map(({ data, ...tx }) => ({
         ...tx,
         data: JSON.parse(data.toString('utf8')),
     }));
 
     return parsedTraces
+        .filter(
+            (tx) => tx.id > lastEventLogId && tx.block_num >= lastCheckedBlock
+        )
         .map((tx) => {
             if (tx.event_type === EventType.trace) {
                 const findAcounts = (

--- a/src/services/transactions/index.ts
+++ b/src/services/transactions/index.ts
@@ -29,7 +29,7 @@ export async function getWebSocketTraceTransactions({
             WHERE receiver IN (:accounts)
             AND block_num >= :fromBlock
             AND block_num < :toBlock
-            ORDER BY block_num DESC
+            ORDER BY block_num ASC
         ) AS R
         INNER JOIN TRANSACTIONS ON R.seq = TRANSACTIONS.seq`,
         {

--- a/src/services/webSocket/index.ts
+++ b/src/services/webSocket/index.ts
@@ -3,7 +3,7 @@ import constants from '../../constants/config';
 import {
     onTransactionHistory,
     getSocketStateActions as getTransactionsHistorySocketStateActions,
-    manageEventLogSaveInState,
+    manageEventLogSaveAndEmit,
 } from './transactionHistory';
 import { Args } from './transactionHistory/types';
 
@@ -17,7 +17,7 @@ function onConnection(socket: Socket, io: Server) {
     const { clearSocketState } = getTransactionsHistorySocketStateActions(
         socket.id
     );
-    manageEventLogSaveInState(io.sockets.sockets.size);
+    manageEventLogSaveAndEmit(io.sockets.sockets.size);
 
     socket.on(EVENT.TRANSACTION_HISTORY, (args: Args) => {
         console.log(
@@ -27,7 +27,7 @@ function onConnection(socket: Socket, io: Server) {
     });
 
     socket.on(EVENT.DISCONNECT, () => {
-        manageEventLogSaveInState(io.sockets.sockets.size);
+        manageEventLogSaveAndEmit(io.sockets.sockets.size);
         clearSocketState();
 
         console.log('Socket disconnected:', socket.id);

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -115,7 +115,8 @@ async function saveEventLogInState() {
             state.eventLog = {
                 ...state.eventLog,
                 data: EventLogTransactions,
-                lastEventId: EventLogTransactions[EventLogTransactions.length - 1]!.id,
+                lastEventId:
+                    EventLogTransactions[EventLogTransactions.length - 1]!.id,
             };
         }
     } catch (error) {
@@ -340,7 +341,8 @@ async function emitTransactionEvent(
         });
 
     if (isNonEmptyArray(transactionHistory)) {
-        const lastTransactionBlockNum = transactionHistory[transactionHistory.length - 1]!.block_num;
+        const lastTransactionBlockNum =
+            transactionHistory[transactionHistory.length - 1]!.block_num;
         setSocketState({
             lastTransactionBlockNum: Number(lastTransactionBlockNum),
             lastCheckedBlock: toBlock,
@@ -374,7 +376,7 @@ async function emitEventLogEvent(socketId: SocketId) {
         socketState.lastCheckedBlock
     );
 
-    const lastEventLog = state.eventLog.data[0];
+    const lastEventLog = state.eventLog.data[state.eventLog.data.length - 1];
     if (lastEventLog) {
         setSocketState({
             lastCheckedBlock: lastEventLog.block_num,

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -115,7 +115,8 @@ async function saveEventLogInState() {
             state.eventLog = {
                 ...state.eventLog,
                 data: EventLogTransactions,
-                lastEventId: EventLogTransactions[0].id,
+                lastEventId:
+                    EventLogTransactions[EventLogTransactions.length - 1]!.id,
             };
         }
     } catch (error) {
@@ -340,7 +341,8 @@ async function emitTransactionEvent(
         });
 
     if (isNonEmptyArray(transactionHistory)) {
-        const lastTransactionBlockNum = transactionHistory[0].block_num;
+        const lastTransactionBlockNum =
+            transactionHistory[transactionHistory.length - 1]!.block_num;
         setSocketState({
             lastTransactionBlockNum: Number(lastTransactionBlockNum),
             lastCheckedBlock: toBlock,

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -112,7 +112,7 @@ async function saveEventLogInState() {
             state.eventLog = {
                 ...state.eventLog,
                 data: EventLogTransactions,
-                lastEventId: EventLogTransactions[0]?.id,
+                lastEventId: EventLogTransactions[0].id,
             };
         }
     } catch (error) {

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -106,7 +106,6 @@ function getSocketStateActions(socketId: SocketId) {
         initializeSocketState: (args: Args): void => {
             state.connectedSockets[socketId] = {
                 args,
-                intervalId: null,
                 lastEventLogId: 0,
                 lastTransactionBlockNum: 0,
                 lastCheckedBlock: 0,
@@ -130,10 +129,6 @@ function getSocketStateActions(socketId: SocketId) {
         },
         clearSocketState: (): void => {
             if (state.connectedSockets[socketId]) {
-                const interval = state.connectedSockets[socketId]?.intervalId;
-                if (interval) {
-                    clearInterval(interval);
-                }
                 delete state.connectedSockets[socketId];
             }
             console.log('Cleared socket state for socket:', socketId);
@@ -185,7 +180,6 @@ async function emitTransactionHistory(socket: Socket) {
         lastCheckedBlock,
         tableType,
         args: { accounts, start_block, irreversible },
-        intervalId,
     } = state;
 
     const startBlock = Math.max(start_block ?? headBlock, lastCheckedBlock);
@@ -210,12 +204,8 @@ async function emitTransactionHistory(socket: Socket) {
         console.log(
             `Switched to Transaction Table for socket: ${socket.id} by accounts:(${accounts}).`
         );
-        if (intervalId) {
-            clearInterval(intervalId);
-        }
         setSocketState({
             tableType: TableType.transaction,
-            intervalId: null,
         });
     }
 

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -49,7 +49,7 @@ function manageEventLogSaveInState(connectionsCount: number) {
         console.log(
             `Starting to write EventLog event, active connections: ${connectionsCount}`
         );
-        state.eventLog.intervalId = setInterval(() => {
+        state.eventLog.intervalId = setInterval(async () => {
             if (
                 // check for any active socket connections with 'EventLog' transaction type
                 !Object.values(state.connectedSockets).find(
@@ -58,11 +58,13 @@ function manageEventLogSaveInState(connectionsCount: number) {
             ) {
                 return;
             }
-            saveEventLogInState()
-                .then(() => emitEventLogEventToClients())
-                .catch((error) =>
-                    console.error('error writing EventLog event:', error)
-                );
+
+            try {
+                await saveEventLogInState();
+                emitEventLogEventToClients();
+            } catch (error) {
+                console.error('error writing EventLog event:', error);
+            }
         }, EVENTLOG_WRITING_INTERVAL_TIME);
     }
     if (!connectionsCount && state.eventLog.intervalId) {
@@ -379,6 +381,7 @@ function emitEventLogEventToClients() {
         emitEventLogEvent(client[0], client[1].args.accounts);
     }
 }
+
 export {
     onTransactionHistory,
     getSocketStateActions,

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -61,7 +61,7 @@ function manageEventLogSaveAndEmit(connectionsCount: number) {
 
             try {
                 await saveEventLogInState();
-                emitEventLogEventToClients();
+                emitEventLogsToClients();
             } catch (error) {
                 console.error('error writing EventLog event:', error);
             }
@@ -372,13 +372,12 @@ async function emitEventLogEvent(
     });
 }
 
-function emitEventLogEventToClients() {
-    const eventLogClients = Object.entries(state.connectedSockets).filter(
-        ([_, s]) => s.tableType === TableType.eventLog
-    );
+function emitEventLogsToClients() {
+    const eventLogClients = Object.entries(state.connectedSockets);
 
-    for (const client of eventLogClients) {
-        emitEventLogEvent(client[0], client[1].args.accounts);
+    for (const [socketId, socketState] of eventLogClients) {
+        if (socketState.tableType !== TableType.eventLog) continue;
+        emitEventLogEvent(socketId, socketState.args.accounts);
     }
 }
 

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -195,6 +195,10 @@ async function emitTransactionHistory(socket: Socket) {
         tableType,
     });
 
+    // if table type is event log and it shouldn't be changed to transaction table, then
+    // return, since event logs are emitted in manageEventLogSaveAndEmit
+    if (tableType === TableType.eventLog && !shouldUseTransactionTable) return;
+
     const shouldUseEventLogTable = switchEventLogTable({
         lastCheckedBlock,
         lastIrreversibleBlock,
@@ -221,7 +225,6 @@ async function emitTransactionHistory(socket: Socket) {
         });
         return;
     }
-    if (tableType === TableType.eventLog) return;
 
     handleTransactionEventEmit({
         socket,

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -365,6 +365,7 @@ async function emitEventLogEvent(
     }
 
     if (!isNonEmptyArray(events)) return;
+    console.log(`Socket ${socketId} receives ${events.length} new Event Logs.`);
 
     // if client does not acknowledge emited event in ACKNOWLEDGE_TIME, disconnect it
     const disconnectionTimeout = setTimeout(() => {
@@ -378,6 +379,10 @@ async function emitEventLogEvent(
 }
 
 function emitEventLogsToClients() {
+    if (!state.eventLog.data.length) {
+        console.log('No new Event Logs found. Not emmitting to clients.');
+        return;
+    }
     const eventLogClients = Object.entries(state.connectedSockets);
 
     for (const [socketId, socketState] of eventLogClients) {

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -41,7 +41,7 @@ export function scheduleNextEmit(socket: Socket) {
     }, EMIT_TIMEOUT_TIME);
 }
 
-function manageEventLogSaveInState(connectionsCount: number) {
+function manageEventLogSaveAndEmit(connectionsCount: number) {
     const shouldWrite = connectionsCount > 0 && !state.eventLog.intervalId;
 
     // start writing the EventLog event if there are active socket connections
@@ -222,7 +222,7 @@ async function emitTransactionHistory(socket: Socket) {
     }
     if (tableType === TableType.eventLog) return;
 
-    emitEventBasedOnType({
+    handleTransactionEventEmit({
         socket,
         accounts,
         startBlock,
@@ -232,7 +232,7 @@ async function emitTransactionHistory(socket: Socket) {
     });
 }
 
-async function emitEventBasedOnType({
+async function handleTransactionEventEmit({
     socket,
     accounts,
     startBlock,
@@ -385,5 +385,5 @@ function emitEventLogEventToClients() {
 export {
     onTransactionHistory,
     getSocketStateActions,
-    manageEventLogSaveInState,
+    manageEventLogSaveAndEmit,
 };

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -356,10 +356,7 @@ async function emitTransactionEvent(
     }
 }
 
-async function emitEventLogEvent(
-    socketId: SocketId,
-    accounts: Args['accounts']
-) {
+async function emitEventLogEvent(socketId: SocketId) {
     const { setSocketState, clearSocketState, getSocketState } =
         getSocketStateActions(socketId);
     const socketState = getSocketState();
@@ -367,7 +364,7 @@ async function emitEventLogEvent(
 
     const events = eventLogService.webSocketFormat(
         state.eventLog.data,
-        accounts,
+        socketState.args.accounts,
         socketState.lastEventLogId,
         socketState.lastCheckedBlock
     );
@@ -395,11 +392,12 @@ async function emitEventLogEvent(
 }
 
 function emitEventLogsToClients() {
-    const eventLogClients = Object.entries(state.connectedSockets);
+    const eventLogClients = Object.keys(state.connectedSockets);
 
-    for (const [socketId, socketState] of eventLogClients) {
-        if (socketState.tableType !== TableType.eventLog) continue;
-        emitEventLogEvent(socketId, socketState.args.accounts);
+    for (const socketId of eventLogClients) {
+        if (state.connectedSockets[socketId]?.tableType !== TableType.eventLog)
+            continue;
+        emitEventLogEvent(socketId);
     }
 }
 

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -73,6 +73,7 @@ function manageEventLogSaveAndEmit(connectionsCount: number) {
         // if there are no active socket connections
         clearInterval(state.eventLog.intervalId);
         state.eventLog = { data: [], lastEventId: null, intervalId: null };
+        console.log('No connections found. Stop writing EventLog event.');
     }
 }
 

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -109,6 +109,9 @@ async function saveEventLogInState() {
         });
 
         if (isNonEmptyArray(EventLogTransactions)) {
+            console.log(
+                `${EventLogTransactions.length} new Event Log events. Writing to state.`
+            );
             state.eventLog = {
                 ...state.eventLog,
                 data: EventLogTransactions,

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -108,12 +108,13 @@ async function saveEventLogInState() {
             toId: Number(fromId) + EVENTLOG_BLOCKS_LIMIT,
         });
 
-        state.eventLog = {
-            ...state.eventLog,
-            data: EventLogTransactions,
-            lastEventId:
-                EventLogTransactions[0]?.id ?? state.eventLog.lastEventId,
-        };
+        if (isNonEmptyArray(EventLogTransactions)) {
+            state.eventLog = {
+                ...state.eventLog,
+                data: EventLogTransactions,
+                lastEventId: EventLogTransactions[0]?.id,
+            };
+        }
     } catch (error) {
         console.error('error saving EventLog in state:', error);
     }
@@ -394,10 +395,6 @@ async function emitEventLogEvent(
 }
 
 function emitEventLogsToClients() {
-    if (!state.eventLog.data.length) {
-        console.log('No new Event Logs found. Not emmitting to clients.');
-        return;
-    }
     const eventLogClients = Object.entries(state.connectedSockets);
 
     for (const [socketId, socketState] of eventLogClients) {

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -351,6 +351,15 @@ async function emitEventLogEvent(
     socket: Socket,
     { accounts }: { accounts: Args['accounts'] }
 ) {
+    const { setSocketState } = getSocketStateActions(socket.id);
+    const lastBlockNumber = state.eventLog.data[0]?.block_num;
+
+    if (lastBlockNumber) {
+        setSocketState({
+            lastCheckedBlock: lastBlockNumber,
+        });
+    }
+
     const events = eventLogService.webSocketFormat(
         state.eventLog.data,
         accounts

--- a/src/services/webSocket/transactionHistory/index.ts
+++ b/src/services/webSocket/transactionHistory/index.ts
@@ -250,7 +250,6 @@ async function emitTransactionHistory(socket: Socket) {
         accounts,
         startBlock,
         lastIrreversibleBlock,
-        irreversible,
         headBlock,
     });
 }
@@ -260,14 +259,12 @@ async function handleTransactionEventEmit({
     accounts,
     startBlock,
     lastIrreversibleBlock,
-    irreversible,
     headBlock,
 }: {
     socket: Socket;
     accounts: Args['accounts'];
     startBlock: number;
     lastIrreversibleBlock: number;
-    irreversible: Args['irreversible'];
     headBlock: number;
 }) {
     const { getSocketState, setSocketState } = getSocketStateActions(socket.id);
@@ -289,9 +286,7 @@ async function handleTransactionEventEmit({
 
         const threshold = calculateTraceTxsBlockThreshold(count, startBlock);
 
-        let toBlock = irreversible
-            ? Math.min(threshold, lastIrreversibleBlock)
-            : threshold;
+        let toBlock = Math.min(threshold, lastIrreversibleBlock);
 
         shouldExecute =
             startBlock <= toBlock &&
@@ -364,7 +359,9 @@ async function emitEventLogEvent(socketId: SocketId) {
         getSocketStateActions(socketId);
     const socketState = getSocketState();
     if (!socketState) {
-        console.log(`Tried to emit EventLog event to socket ${socketId} but could not find the state.`);
+        console.log(
+            `Tried to emit EventLog event to socket ${socketId} but could not find the state.`
+        );
         return;
     }
 

--- a/src/services/webSocket/transactionHistory/types.ts
+++ b/src/services/webSocket/transactionHistory/types.ts
@@ -28,7 +28,6 @@ export interface SocketState {
     tableType: TableType;
     lastTransactionBlockNum: number;
     lastCheckedBlock: number;
-    intervalId: NodeJS.Timeout | null;
     lastEventLogId: number;
 }
 

--- a/src/services/webSocket/transactionHistory/types.ts
+++ b/src/services/webSocket/transactionHistory/types.ts
@@ -28,6 +28,8 @@ export interface SocketState {
     tableType: TableType;
     lastTransactionBlockNum: number;
     lastCheckedBlock: number;
+    intervalId: NodeJS.Timeout | null;
+    lastEventLogId: number;
 }
 
 export interface Args {

--- a/src/services/webSocket/transactionHistory/types.ts
+++ b/src/services/webSocket/transactionHistory/types.ts
@@ -19,7 +19,7 @@ export interface State {
     eventLog: {
         data: EventLog[];
         lastEventId: number | null;
-        intervalId: NodeJS.Timeout | null;
+        timeoutId: NodeJS.Timeout | null;
     };
 }
 


### PR DESCRIPTION
# Short description
_**What does this PR?**_

Fixes the inconsistency of websockets that may send transactions after 3 minutes instead of immediately and sometimes even not send them at all.

# Changes
- Emitting eventLog event updates the last checked block
- EventLog event is now emitted in one cycle with updating the state
- State is now emitted using timeouts instead of intervals to prevent unexpected behaviour in the future that may have been caused if the state update took more than the update interval time (currently 500ms)

# How can it be tested
Change `.env` to connect to testnet
Start the server
Connect to it via websockets as in the example providing the arguments
Start making the transactions with the provided accounts. They should be sent to you almost immediately.